### PR TITLE
Hide empty counter placeholders while loading

### DIFF
--- a/github-btn.html
+++ b/github-btn.html
@@ -144,6 +144,11 @@ body {
     } else {
       counter.innerHTML = addCommas(obj.data.forks);
     }
+
+    // Show the count if asked
+    if (count == 'true') {
+      counter.style.display = 'block'
+    }
   }
 
   // Set href to be URL for repo
@@ -158,11 +163,6 @@ body {
     mainButton.className += ' github-forks';
     text.innerHTML = 'Fork';
     counter.href = 'https://github.com/' + user + '/' + repo + '/network';
-  }
-
-  // Show the count if asked
-  if (count == 'true') {
-    counter.style.display = 'block'
   }
 
   // Change the size


### PR DESCRIPTION
If a counter is enabled, a collapsed rounded placeholder is visible while waiting for the GitHub API to respond. This changes the placeholder to only appear after the API responds.
