### PR TITLE
Add focus states for buttons and counters

### DIFF
--- a/github-btn.html
+++ b/github-btn.html
@@ -42,7 +42,8 @@ body {
      -moz-box-shadow: inset 0 1px 0 rgba(255,255,255,.2);
           box-shadow: inset 0 1px 0 rgba(255,255,255,.2);
 }
-.gh-btn:hover {
+.gh-btn:hover,
+.gh-btn:focus {
   color: #333;
   text-decoration: none;
   background-position: 0 -10px;
@@ -60,7 +61,8 @@ body {
   background: url(github-icons.png) no-repeat 0 0;
   opacity: .65;
 }
-.gh-btn:hover .gh-ico {
+.gh-btn:hover .gh-ico,
+.gh-btn:focus .gh-ico {
   opacity: .75;
 }
 .gh-count {
@@ -69,7 +71,8 @@ body {
   background-color: #fff;
   border: 1px solid #ddd;
 }
-.gh-count:hover {
+.gh-count:hover,
+.gh-count:focus {
   color: #333;
   background-color: #f5f5f5;
   border-color: #d5d5d5;


### PR DESCRIPTION
This adds focus states (mirroring the hover states) for users who need to tab through links to use them.
