### PR TITLE
Bug fix for FF3.6

### DIFF
--- a/github-btn.html
+++ b/github-btn.html
@@ -1,4 +1,4 @@
-<style type="text/css">
+<html><body><style type="text/css">
 body {
   padding: 0;
   margin: 0;
@@ -171,4 +171,4 @@ body {
   }
 
   jsonp('https://api.github.com/repos/' + user + '/' + repo);
-</script>
+</script></body></html>


### PR DESCRIPTION
Added html and body tags to make the page valid html - javascript was returning 'button is null' in Firefox 3.6
