### PR TITLE
Add "View Source on GitHub" button

### DIFF
--- a/github-btn.html
+++ b/github-btn.html
@@ -173,7 +173,11 @@ body {
     text.innerHTML = 'Follow @' + user;
     button.href = 'https://github.com/' + user;
     counter.href = 'https://github.com/' + user + '/followers';
+  } else if (type == 'viewsource') {
+    mainButton.className += ' github-viewsource';
+    text.innerHTML = 'View Source on GitHub';
   }
+  
 
   // Change the size
   if (size == 'large') {


### PR DESCRIPTION
Hey there,
This is a really small change. Here's the idea: I'm working on my personal site, and think I'll have audiences that are interested in checking out the code behind a project but aren't super-familiar with github and/or don't want to watch the repository. Since all the "watch" button really does is take a user to a repository's page, I added a 4th type of button with the same functionality whose text instead reads "View Source on GitHub." I think that might make it more friendly to casual audiences. Let me know what you think, and if you like it I'll send the same pull request on gh-pages and update the docs.
-jflinter
