### PR TITLE
fixes for issues #44, #42, #47

### DIFF
--- a/github-btn.html
+++ b/github-btn.html
@@ -209,7 +209,7 @@ body {
         jsonp(obj.data.stargazers_url, 'stargazerCount');
         break;
       case 'fork':
-        counter.innerHTML = addCommas(obj.data.forks);
+        counter.innerHTML = addCommas(obj.data.network_count);
         break;
       case 'follow':
         counter.innerHTML = addCommas(obj.data.followers);


### PR DESCRIPTION
The issue #44 seems to be caused by an overload of the GitHub API. Do not display the count when API returns "undefined".

Issue #42: support was added for proper "star" button (with correct count), and "watch" button now displays correct information/count.

Issue #47 resolved by reading network_count property on response object.
