### PR TITLE
Direct link to fork

### DIFF
--- a/github-btn.source.html
+++ b/github-btn.source.html
@@ -214,6 +214,7 @@ body {
   } else if (type == 'fork') {
     mainButton.className += ' github-forks';
     text.innerHTML = 'Fork';
+    button.href += 'fork';
     counter.href = 'https://github.com/' + user + '/' + repo + '/network';
   } else if (type == 'follow') {
     mainButton.className += ' github-me';


### PR DESCRIPTION
Unlike the "follow" and the "star" buttons which GitHub uses forms for, the "fork" button is just a link which points to github.com/user/repo/fork.
The "fork" button here should probably do the same.