### PR TITLE
layout: Fix 404 error Apache license link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,7 +23,7 @@
       <p>Introducing the unofficial</p>
       <h1>GitHub buttons</h1>
       <p>Showcase your GitHub repo&#39;s success with hotlinkable GitHub star, fork, or follow buttons. Available in two sizes with up-to-date counts.</p>
-      <p>Made by <a href="http://twitter.com/mdo">@mdo</a>. Available on <a href="https://github.com/mdo/github-buttons">GitHub</a>. Licensed <a href="http://www.apache.org/licenses/LICENSE-2.0&quot;">Apache 2</a>.</p>
+      <p>Made by <a href="http://twitter.com/mdo">@mdo</a>. Available on <a href="https://github.com/mdo/github-buttons">GitHub</a>. Licensed <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache 2</a>.</p>
 
       <hr>
 


### PR DESCRIPTION
https://ghbtns.com/
-> http://www.apache.org/licenses/LICENSE-2.0%22