### PR TITLE
Update the link for ntkme/github-buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The GitHub buttons site is built with Jekyll (requires Ruby and more). The HTML 
 
 ## See also
 
-- [ntkme/github-buttons](https://github.com/ntkme/github-buttons)
+- [ntkme/github-buttons](https://buttons.github.io)
 
 ## Twitter account
 


### PR DESCRIPTION
This PR updates the link for [ntkme/github-buttons](https://github.com/ntkme/github-buttons), which now points to its [button generator](https://buttons.github.io).