### PR TITLE
Add jekyll-seo-tag and robots.txt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'jekyll', '~> 4.1.1'
+gem 'jekyll-seo-tag', '~> 2.6.1'
 gem 'wdm', '~> 0.1.1', :install_if => Gem.win_platform?

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,9 +33,11 @@ GEM
       terminal-table (~> 1.8)
     jekyll-sass-converter (2.1.0)
       sassc (> 2.0.1, < 3.0)
+    jekyll-seo-tag (2.6.1)
+      jekyll (>= 3.3, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kramdown (2.2.1)
+    kramdown (2.3.0)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
@@ -68,6 +70,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (~> 4.1.1)
+  jekyll-seo-tag (~> 2.6.1)
   wdm (~> 0.1.1)
 
 BUNDLED WITH

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,18 @@
-permalink: pretty
+title:          "Unofficial GitHub Buttons"
+description:    "A set of static buttons with dynamic watch and fork counts for any repo hosted on GitHub."
+url:            "https://ghbtns.com"
+
+# Social
+authors:        "Mark Otto"
+author:
+  twitter:      "mdo"
+
+permalink:      pretty
 
 sass:
   style: compressed
 
 source: docs
+
+plugins:
+  - jekyll-seo-tag

--- a/docs/_includes/example.html
+++ b/docs/_includes/example.html
@@ -11,7 +11,8 @@
 {%- assign class = include.class -%}
 
 <div{% if id %} id="{{ id }}"{% endif %} class="example{% if class %} {{ class }}{% endif %}">
-  {{- include.content | replace: 'https://ghbtns.com/', '' | replace: ' frameborder="0" scrolling="0"' '' -}}
+  {%- assign url = site.url | append: '/' -%}
+  {{- include.content | replace: url, '' | replace: ' frameborder="0" scrolling="0"' '' -}}
 </div>
 
 {%- highlight html -%}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -3,12 +3,10 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>The Unofficial GitHub Watch &amp; Fork Buttons</title>
-    <meta name="author" content="Mark Otto">
-    <meta name="description" content="A set of static buttons with dynamic watch and fork counts for any repo hosted on GitHub.">
-    <meta name="generator" content="Jekyll v{{ jekyll.version }}">
-    <link rel="canonical" href="https://ghbtns.com/">
+    <meta name="author" content="{{ site.authors }}">
     <link rel="dns-prefetch" href="https://api.github.com">
+
+    {% seo %}
     <style>
     {%- capture include_to_scssify -%}
       {%- include page.scss -%}

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,9 +13,9 @@ layout: default
 ## Star
 
 {% capture example %}
-<iframe src="https://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=star&count=true&size=large" frameborder="0" scrolling="0" width="170" height="30" title="GitHub"></iframe>
+<iframe src="{{ site.url }}/github-btn.html?user=twbs&repo=bootstrap&type=star&count=true&size=large" frameborder="0" scrolling="0" width="170" height="30" title="GitHub"></iframe>
 
-<iframe src="https://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=star&count=true" frameborder="0" scrolling="0" width="150" height="20" title="GitHub"></iframe>
+<iframe src="{{ site.url }}/github-btn.html?user=twbs&repo=bootstrap&type=star&count=true" frameborder="0" scrolling="0" width="150" height="20" title="GitHub"></iframe>
 {% endcapture %}
 {% include example.html content=example %}
 
@@ -26,36 +26,36 @@ Originally, GitHub's Watch button was used for notification settings (today's Wa
 As such, for today's unofficial Watch button, **you must add `v=2` to the parameters**. If you don't, you'll get [the deprecated button](#deprecated).
 
 {% capture example %}
-<iframe src="https://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=watch&count=true&size=large&v=2" frameborder="0" scrolling="0" width="170" height="30" title="GitHub"></iframe>
+<iframe src="{{ site.url }}/github-btn.html?user=twbs&repo=bootstrap&type=watch&count=true&size=large&v=2" frameborder="0" scrolling="0" width="170" height="30" title="GitHub"></iframe>
 
-<iframe src="https://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=watch&count=true&v=2" frameborder="0" scrolling="0" width="150" height="20" title="GitHub"></iframe>
+<iframe src="{{ site.url }}/github-btn.html?user=twbs&repo=bootstrap&type=watch&count=true&v=2" frameborder="0" scrolling="0" width="150" height="20" title="GitHub"></iframe>
 {% endcapture %}
 {% include example.html content=example %}
 
 ## Fork
 
 {% capture example %}
-<iframe src="https://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=fork&count=true&size=large" frameborder="0" scrolling="0" width="170" height="30" title="GitHub"></iframe>
+<iframe src="{{ site.url }}/github-btn.html?user=twbs&repo=bootstrap&type=fork&count=true&size=large" frameborder="0" scrolling="0" width="170" height="30" title="GitHub"></iframe>
 
-<iframe src="https://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=fork&count=true" frameborder="0" scrolling="0" width="150" height="20" title="GitHub"></iframe>
+<iframe src="{{ site.url }}/github-btn.html?user=twbs&repo=bootstrap&type=fork&count=true" frameborder="0" scrolling="0" width="150" height="20" title="GitHub"></iframe>
 {% endcapture %}
 {% include example.html content=example %}
 
 ## Follow
 
 {% capture example %}
-<iframe src="https://ghbtns.com/github-btn.html?user=mdo&type=follow&count=true&size=large" frameborder="0" scrolling="0" width="230" height="30" title="GitHub"></iframe>
+<iframe src="{{ site.url }}/github-btn.html?user=mdo&type=follow&count=true&size=large" frameborder="0" scrolling="0" width="230" height="30" title="GitHub"></iframe>
 
-<iframe src="https://ghbtns.com/github-btn.html?user=mdo&type=follow&count=true" frameborder="0" scrolling="0" width="170" height="20" title="GitHub"></iframe>
+<iframe src="{{ site.url }}/github-btn.html?user=mdo&type=follow&count=true" frameborder="0" scrolling="0" width="170" height="20" title="GitHub"></iframe>
 {% endcapture %}
 {% include example.html content=example %}
 
 ## Sponsor
 
 {% capture example %}
-<iframe src="https://ghbtns.com/github-btn.html?user=mdo&type=sponsor&size=large" frameborder="0" scrolling="0" width="180" height="30" title="GitHub"></iframe>
+<iframe src="{{ site.url }}/github-btn.html?user=mdo&type=sponsor&size=large" frameborder="0" scrolling="0" width="180" height="30" title="GitHub"></iframe>
 
-<iframe src="https://ghbtns.com/github-btn.html?user=mdo&type=sponsor" frameborder="0" scrolling="0" width="150" height="20" title="GitHub"></iframe>
+<iframe src="{{ site.url }}/github-btn.html?user=mdo&type=sponsor" frameborder="0" scrolling="0" width="150" height="20" title="GitHub"></iframe>
 {% endcapture %}
 {% include example.html content=example %}
 
@@ -97,9 +97,9 @@ With the button split in August 2012, GitHub's API continued to return the Star 
 This deprecated button is still around to avoid breaking every site that currently utilizes these embeds.
 
 {% capture example %}
-<iframe src="https://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=watch&count=true&size=large" frameborder="0" scrolling="0" width="170" height="30" title="GitHub"></iframe>
+<iframe src="{{ site.url }}/github-btn.html?user=twbs&repo=bootstrap&type=watch&count=true&size=large" frameborder="0" scrolling="0" width="170" height="30" title="GitHub"></iframe>
 
-<iframe src="https://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=watch&count=true" frameborder="0" scrolling="0" width="170" height="20" title="GitHub"></iframe>
+<iframe src="{{ site.url }}/github-btn.html?user=twbs&repo=bootstrap&type=watch&count=true" frameborder="0" scrolling="0" width="170" height="20" title="GitHub"></iframe>
 {% endcapture %}
 {% include example.html content=example %}
 

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,5 @@
+# www.robotstxt.org/
+
+# Allow crawling of all content
+User-agent: *
+Disallow:


### PR DESCRIPTION
@mdo this needs some tweaking for site.title and site.description

Later we can add a social image etc.

PS. locally, when developing (with `bundle exec jekyll serve`), the `url` for the example snippet is set to `http://localhost:4000` but for production it's the value of `site.url`. So, as long as we deploy automatically we should be fine. `github-btn.html` is always loaded relatively regardless of the `url`.