### PR TITLE
docs: change markup's title

### DIFF
--- a/index.md
+++ b/index.md
@@ -13,9 +13,9 @@ layout: default
 ## Star
 
 {% capture example %}
-<iframe src="https://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=star&count=true&size=large" frameborder="0" scrolling="0" width="170" height="30" title="Star twbs/bootstrap on GitHub"></iframe>
+<iframe src="https://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=star&count=true&size=large" frameborder="0" scrolling="0" width="170" height="30" title="GitHub"></iframe>
 
-<iframe src="https://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=star&count=true" frameborder="0" scrolling="0" width="150" height="20" title="Star twbs/bootstrap on GitHub"></iframe>
+<iframe src="https://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=star&count=true" frameborder="0" scrolling="0" width="150" height="20" title="GitHub"></iframe>
 {% endcapture %}
 {% include example.html content=example %}
 
@@ -26,36 +26,36 @@ Originally, GitHub's Watch button was used for notification settings (today's Wa
 As such, for today's unofficial Watch button, **you must add `v=2` to the parameters**. If you don't, you'll get [the deprecated button](#deprecated).
 
 {% capture example %}
-<iframe src="https://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=watch&count=true&size=large&v=2" frameborder="0" scrolling="0" width="170" height="30" title="Watch twbs/bootstrap on GitHub"></iframe>
+<iframe src="https://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=watch&count=true&size=large&v=2" frameborder="0" scrolling="0" width="170" height="30" title="GitHub"></iframe>
 
-<iframe src="https://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=watch&count=true&v=2" frameborder="0" scrolling="0" width="150" height="20" title="Watch twbs/bootstrap on GitHub"></iframe>
+<iframe src="https://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=watch&count=true&v=2" frameborder="0" scrolling="0" width="150" height="20" title="GitHub"></iframe>
 {% endcapture %}
 {% include example.html content=example %}
 
 ## Fork
 
 {% capture example %}
-<iframe src="https://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=fork&count=true&size=large" frameborder="0" scrolling="0" width="170" height="30" title="Fork twbs/bootstrap on GitHub"></iframe>
+<iframe src="https://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=fork&count=true&size=large" frameborder="0" scrolling="0" width="170" height="30" title="GitHub"></iframe>
 
-<iframe src="https://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=fork&count=true" frameborder="0" scrolling="0" width="150" height="20" title="Fork twbs/bootstrap on GitHub"></iframe>
+<iframe src="https://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=fork&count=true" frameborder="0" scrolling="0" width="150" height="20" title="GitHub"></iframe>
 {% endcapture %}
 {% include example.html content=example %}
 
 ## Follow
 
 {% capture example %}
-<iframe src="https://ghbtns.com/github-btn.html?user=mdo&type=follow&count=true&size=large" frameborder="0" scrolling="0" width="230" height="30" title="Follow @mdo on GitHub"></iframe>
+<iframe src="https://ghbtns.com/github-btn.html?user=mdo&type=follow&count=true&size=large" frameborder="0" scrolling="0" width="230" height="30" title="GitHub"></iframe>
 
-<iframe src="https://ghbtns.com/github-btn.html?user=mdo&type=follow&count=true" frameborder="0" scrolling="0" width="170" height="20" title="Follow @mdo on GitHub"></iframe>
+<iframe src="https://ghbtns.com/github-btn.html?user=mdo&type=follow&count=true" frameborder="0" scrolling="0" width="170" height="20" title="GitHub"></iframe>
 {% endcapture %}
 {% include example.html content=example %}
 
 ## Sponsor
 
 {% capture example %}
-<iframe src="https://ghbtns.com/github-btn.html?user=mdo&type=sponsor&size=large" frameborder="0" scrolling="0" width="180" height="30" title="Sponsor @mdo on GitHub"></iframe>
+<iframe src="https://ghbtns.com/github-btn.html?user=mdo&type=sponsor&size=large" frameborder="0" scrolling="0" width="180" height="30" title="GitHub"></iframe>
 
-<iframe src="https://ghbtns.com/github-btn.html?user=mdo&type=sponsor" frameborder="0" scrolling="0" width="150" height="20" title="Sponsor @mdo on GitHub"></iframe>
+<iframe src="https://ghbtns.com/github-btn.html?user=mdo&type=sponsor" frameborder="0" scrolling="0" width="150" height="20" title="GitHub"></iframe>
 {% endcapture %}
 {% include example.html content=example %}
 
@@ -97,9 +97,9 @@ With the button split in August 2012, GitHub's API continued to return the Star 
 This deprecated button is still around to avoid breaking every site that currently utilizes these embeds.
 
 {% capture example %}
-<iframe src="https://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=watch&count=true&size=large" frameborder="0" scrolling="0" width="170" height="30" title="Watch twbs/bootstrap on GitHub"></iframe>
+<iframe src="https://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=watch&count=true&size=large" frameborder="0" scrolling="0" width="170" height="30" title="GitHub"></iframe>
 
-<iframe src="https://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=watch&count=true" frameborder="0" scrolling="0" width="170" height="20" title="Watch twbs/bootstrap on GitHub"></iframe>
+<iframe src="https://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=watch&count=true" frameborder="0" scrolling="0" width="170" height="20" title="GitHub"></iframe>
 {% endcapture %}
 {% include example.html content=example %}
 
@@ -131,8 +131,8 @@ More refinement and functionality is planned with open-sourcing—any help is al
 The unofficial GitHub buttons are available on GitHub for downloading, forking, or contributing.
 
 <p>
-  <iframe src="github-btn.html?user=mdo&repo=github-buttons&type=star&count=true&size=large" width="160" height="30" title="Star mdo/github-buttons on GitHub"></iframe>
-  <iframe src="github-btn.html?user=mdo&repo=github-buttons&type=fork&count=true&size=large" width="160" height="30" title="Star mdo/github-buttons on GitHub"></iframe>
+  <iframe src="github-btn.html?user=mdo&repo=github-buttons&type=star&count=true&size=large" width="160" height="30" title="GitHub"></iframe>
+  <iframe src="github-btn.html?user=mdo&repo=github-buttons&type=fork&count=true&size=large" width="160" height="30" title="GitHub"></iframe>
 </p>
 
 <a href="https://github.com/mdo/github-buttons" class="btn">View on GitHub</a>


### PR DESCRIPTION
Since we add a title in the iframe itself and we have an `aria-label` this was redundant.

@patrickhlauke can you confirm everything looks good now please? ❤

Preview: <https://optimistic-swanson-3a1e25.netlify.app/>
