### PR TITLE
Add an image only variation with `text=false`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,13 @@ As such, for today's unofficial Watch button, **you must add `v=2` to the parame
 {% endcapture %}
 {% include example.html content=example %}
 
+## No text variant
+
+{% capture example %}
+<iframe src="{{ site.url }}/github-btn.html?user=twbs&repo=bootstrap&type=star&size=large&text=false" frameborder="0" scrolling="0" width="170" height="30" title="GitHub"></iframe>
+{% endcapture %}
+{% include example.html content=example %}
+
 ---
 
 ## Available options
@@ -85,6 +92,7 @@ The following URL parameters are **not** required. Add them as you wish.
 | ------ | :---------- |
 | `count` | Show the optional watchers or forks count: *none* by default or `true` |
 | `size` | Optional flag for using a larger button: *none* by default or `large` |
+| `text` | Optional flag for hiding the text: *none* by default or `false` |
 
 ---
 

--- a/src/js.js
+++ b/src/js.js
@@ -40,6 +40,7 @@
   var count = parameters.count;
   var size = parameters.size;
   var v = parameters.v;
+  var noText = parameters.text;
 
   // Elements
   var button = document.querySelector('.gh-btn');
@@ -155,6 +156,13 @@
     }
   }
 
+  if (noText === 'false') {
+    button.className += ' no-text';
+    text.setAttribute('aria-hidden', true);
+    text.style.display = 'none';
+    text.textContent = '';
+  }
+
   button.setAttribute('aria-label', title + LABEL_SUFFIX);
   document.title = title + LABEL_SUFFIX;
 
@@ -165,7 +173,7 @@
 
   // If count is not requested or type is sponsor,
   // there's no need to make an API call
-  if (count !== 'true' || type === 'sponsor') {
+  if (count !== 'true' || type === 'sponsor' || noText === 'false') {
     return;
   }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -117,3 +117,6 @@ body {
   margin-top: -7px;
   border-width: 7px 7px 7px 0;
 }
+.no-text .gh-ico {
+  margin-right: 0;
+}


### PR DESCRIPTION
Fixes #141 

TODO:

- [x] Add an example in docs