### PR TITLE
Add a dark mode

### DIFF
--- a/src/js.js
+++ b/src/js.js
@@ -40,6 +40,7 @@
   var count = parameters.count;
   var size = parameters.size;
   var v = parameters.v;
+  var theme = parameters.theme;
 
   // Elements
   var button = document.querySelector('.gh-btn');
@@ -159,3 +160,7 @@
     jsonp(API_URL + 'repos/' + user + '/' + repo);
   }
 })();
+
+if (theme === dark) {
+  document.getElementsByTagName("body")[0].setAttribute("class", "dark");
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -115,3 +115,6 @@ body {
   margin-top: -7px;
   border-width: 7px 7px 7px 0;
 }
+.dark {
+  filter: invert(100%);
+}


### PR DESCRIPTION
Setting `dark` to `true` should make the button dark. This patch fixes that.