### PR TITLE
chore: add name and year to license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2011 Mark Otto
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
We were about to fork / modify it and having a license template in our repo felt wrong.

According to my knowledge the year means the first year of the project, so 2011 should be fine.